### PR TITLE
Updated Catalyst for older cards from 12.6 to 13.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Steam for Linux requires the following:
 - Ubuntu 12.04 LTS, fully updated
 - Latest graphics driver
 - NVidia driver support - For recent cards (e.g. series 8), you will need to install 310.x. For older cards, driver 304.x supports the NVidia 6 and 7 GPU series. To access these drivers, first update your cache and then install the specific [driver](https://support.steampowered.com/kb_article.php?ref=8509-RFXM-1964) you need from the list in Additional Drivers.
-- AMD driver support - For recent cards (e.g. series 5 and above), we recommend installing the 12.11 driver. For older cards, Catalyst 12.6 supports the HD 2400 Pro card and is the latest for the 2 and 4 GPU series.
+- AMD driver support - For recent cards (e.g. series 5 and above), we recommend installing the 12.11 driver. For older cards, Catalyst 13.1 Legacy supports the HD 2400 Pro card and is the latest for the 2 and 4 GPU series.
 - Intel HD 3000/4000 driver support - you will need to use the latest Mesa drivers, Mesa 9 or later. For installation instructions, see [here](http://wiki.ubuntu.com/Valve).
 
 Getting Started


### PR DESCRIPTION
Updated Catalyst for older cards from 12.6 to 13.1 and added "Legacy" in front for clarification. The Catalyst 13.1 legacy driver also supports the the necessary extensions for Team Fortress 2 so it should be the recommended driver.
