### PR TITLE
README: Document x86-64 requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,12 @@ Hardware and Software Requirements
 ----------------------------------
 Steam for Linux requires the following:
 
-- 1 GHz Pentium 4 or AMD Opteron with 512 megabytes of RAM and 5 gigabytes of hard drive space, or better
+- 1 GHz Pentium 4 or AMD Opteron with x86-64 (AMD64) instruction set
+- 512 megabytes of RAM and 5 gigabytes of hard drive space, or better
 - Internet connection (Cable/DSL speeds recommended)
 - Latest Ubuntu LTS, fully updated
+- 64-bit (x86-64, AMD64) Linux kernel
+- 64-bit (x86-64, AMD64) *and* 32-bit (i386, IA32) graphics drivers and glibc
 - Latest graphics driver
 - NVidia driver support - For recent cards (e.g. series 8), you will need to install 310.x. For older cards, driver 304.x supports the NVidia 6 and 7 GPU series. To access these drivers, first update your cache and then install the specific [driver](https://support.steampowered.com/kb_article.php?ref=8509-RFXM-1964) you need from the list in Additional Drivers.
 - AMD driver support - For recent cards (e.g. series 5 and above), we recommend installing the 12.11 driver. For older cards, Catalyst 13.1 Legacy supports the HD 2400 Pro card and is the latest for the 2 and 4 GPU series.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,9 @@ Hardware and Software Requirements
 ----------------------------------
 Steam for Linux requires the following:
 
-- 1 GHz Pentium 4 or AMD Opteron with x86-64 (AMD64) instruction set
+- 1 GHz Pentium 4 or AMD Opteron with:
+    - x86-64 (AMD64) instruction set
+    - CMPXCHG16B instruction support (`cx16` in `/proc/cpuinfo` flags)
 - 512 megabytes of RAM and 5 gigabytes of hard drive space, or better
 - Internet connection (Cable/DSL speeds recommended)
 - Latest Ubuntu LTS, fully updated

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Steam for Linux requires the following:
 - 1 GHz Pentium 4 or AMD Opteron with:
     - x86-64 (AMD64) instruction set
     - CMPXCHG16B instruction support (`cx16` in `/proc/cpuinfo` flags)
+    - SSE3 instruction support (`pni` in `/proc/cpuinfo` flags)
 - 512 megabytes of RAM and 5 gigabytes of hard drive space, or better
 - Internet connection (Cable/DSL speeds recommended)
 - Latest Ubuntu LTS, fully updated


### PR DESCRIPTION
Recent versions of the steamwebhelper process
(~/.steam/root/ubuntu12_64/steamwebhelper) are x86-64 executables, and
steamwebhelper is required for a lot of the Steam Client's UI. Many newer
games are also x86-64 executables.

The Steam Client itself and older games continue to be i386 (IA32)
executables, so support for both ABIs is currently necessary.

The 64-bit requirement is difficult to document in terms of Intel brand
names, because most Pentium 4 revisions are i386/IA32-only (more
specifically i686 with SSE2 and sometimes SSE3), but according to
Wikipedia, the Pentium 4 F-series added x86-64/AMD64 support. Pentium D
appears to have been the first Intel brand name that exclusively refers
to x86-64/AMD64 CPUs.

On the AMD side, all Opterons are x86-64/AMD64, so the requirement is
simple to document.