### PR TITLE
README: Clarify lack of support for Ubuntu oldLTS, especially ESM

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Hardware and Software Requirements
 Steam for Linux requires the following:
 
 - OS: Latest Ubuntu or Ubuntu LTS with a 64-bit (`x86_64`, `AMD64`) Linux kernel
+    - Older Ubuntu LTS branches are not supported and may stop working in a future Steam release, especially the branches in ESM status (Ubuntu 18.04 or older).
 - Processor: 1GHz Pentium 4 or AMD Opteron equivalent or better
     - Any `x86_64` / `AMD64` CPU with support for the `CMPXCHG16B` and `SSE3` instruction sets
 - Memory: 512 MB RAM


### PR DESCRIPTION
Ubuntu has several maintained LTS (long term support) releases at any given time. For example, at the time of writing, Ubuntu 24.04 is both the current release and the current LTS, while 22.04 and 20.04 are older LTS releases within the 5 year lifetime that receives public security updates, and 18.04 and 16.04 are within the 10 year ESM (extended security maintenance) lifetime that can receive security updates with an Ubuntu Pro subscription. There is often also a short-term-support release such as 23.10, which are only supported by Canonical for 9 months each.

Steam on Linux originally targeted Ubuntu 12.04 LTS, but it already does not work on 12.04 (it now requires a newer version of libX11, and the steam-launcher packaging requires Python 3.4) or on 14.04 (the steam-launcher packaging now requires apt 1.1).

My understanding of Valve's support policy is that 24.04 LTS is currently the only release that is supported. After 24.10 is released in October, the aim is to support 24.10 and 24.04 LTS in parallel until 25.04 is released, and so on until the next LTS release in 2026; users wishing to run Valve's recommended OS distribution for Steam on Linux can choose to either follow the short-term-supported track with a medium-sized update every 6 months
(24.04 LTS -> 24.10 -> 25.04 -> 25.10 -> 26.04 LTS -> ...), or follow the long-term-supported track with a large update every 2 years (24.04 LTS -> 26.04 LTS -> ...).

Older Ubuntu LTS releases within their 5 year lifetime are not routinely tested, and may have limitations or incompatibilities. Similar to the status of non-Ubuntu OS distributions, Valve will often try to avoid breaking Steam on these distributions, but does not fully support it either, and users stay on an older LTS release at their own risk.

Older Ubuntu LTS releases that have reached ESM status are also not intended to be fully supported, and there is an increased likelihood that a future Steam version will stop working on these older releases or gain external dependencies that cannot be provided by these older releases.

---

@TTimo, is this description accurate?