### PR TITLE
issue_template.md: Fix template with latest GitHub Issues preview

### DIFF
--- a/.github/ISSUE_TEMPLATE/issue_template.md
+++ b/.github/ISSUE_TEMPLATE/issue_template.md
@@ -1,3 +1,9 @@
+---
+name: Issue Report
+about: File an issue report.
+
+---
+
 #### Your system information
 
 * Steam client version (build number or date): 


### PR DESCRIPTION
With these latest [GitHub Issues changes in Preview](https://github.blog/changelog/2025-01-13-evolving-github-issues-public-preview/), the existing issue_template.md stopped functioning.

Currently it only shows a blank issue template after hitting "New Issue":

![image](https://github.com/user-attachments/assets/8f9376d6-efa2-452b-a13d-000160d6c8ef)

Instead, it should show up as a part of the selectable options after hitting "New Issue":

![image](https://github.com/user-attachments/assets/b0585991-cb72-4336-b57f-0ca806b5b531)

which leads to the existing template:

![image](https://github.com/user-attachments/assets/a5006554-dfdc-4905-94db-64c53b4ff1c4)

All that's needed to make the existing template compatible again is moving it to `.github/ISSUE_TEMPLATE/`and adding a name and about field to the beginning of the markdown file. 

Proof of the PR working is available here: https://github.com/matte-schwartz/steam-for-linux/issues by selecting "New Issue". I could also expand on the work I did with Gamescope's issue template if that would be preferable: https://github.com/ValveSoftware/gamescope/tree/master/.github/ISSUE_TEMPLATE